### PR TITLE
Serving frontend & Streamlining build process

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 dist
+server
 
 .env
 *.sqlite

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "nodemon --ext ts --exec ts-node src/index.ts",
     "build": "tsc",
-    "start": "node dist/server.js",
+    "start": "node server/src/index.js",
     "test": "jest"
   },
   "keywords": [],

--- a/backend/src/services/createServer.ts
+++ b/backend/src/services/createServer.ts
@@ -3,11 +3,16 @@ import express, { Request, Response } from 'express';
 import { insertTweet, getAllTweets } from '../database';
 import { generateAuthToken, getUserAuthTokenAndData, registerUser } from './loginRegistration';
 import { SQLDatabase } from '../types';
+import path from 'path';
 
 const createServer = async (db: SQLDatabase) => {
   const app = express();
 
   app.use(express.json());
+
+  const distPath = path.join(__dirname, '../dist');
+  app.use(express.static(path.join(__dirname, distPath)));
+  app.use(express.static(distPath, { extensions: ['js', 'css'] }));
 
   app.get('/api', (req: Request, res: Response) => {
     res.send({ message: 'Working RN' });
@@ -106,6 +111,10 @@ const createServer = async (db: SQLDatabase) => {
         res.status(500).json({ error: 'Failed to Login' });
       }
     }
+  });
+
+  app.get('*', (req, res) => {
+    res.sendFile(path.join(distPath, 'index.html'));
   });
 
   return app;

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,14 +1,11 @@
 {
   "compilerOptions": {
     "target": "es2016",
-
     "module": "commonjs",
-
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-
     "strict": true,
-
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "outDir": "server"
   }
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,4 +12,7 @@ export default defineConfig({
       },
     },
   },
+  build: {
+    outDir: '../backend/server/src/dist',
+  },
 });

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "devops-team-project",
+  "version": "1.0.0",
+  "description": "Twitter clone",
+  "main": "index.js",
+  "scripts": {
+    "build": "cd backend && npm run build && cd .. && cd frontend && npm run build",
+    "start": "node backend/server/src/index.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Evan-OR/devops-team-project.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "bugs": {
+    "url": "https://github.com/Evan-OR/devops-team-project/issues"
+  },
+  "homepage": "https://github.com/Evan-OR/devops-team-project#readme"
+}


### PR DESCRIPTION
**Serving frontend**
Backend will now serve the react app if it have been built

**Streamlining build process**
Instead of needing to cd into both fontend & backend to build the seperatly and move the build folders around. I added a npm script to the project so from the root you can just run `npm run build` and the backend will be built, the frontend will be built and moved to the backends build folder and then you can just run `npm run start` and the built prod server will run.

This should make building production in the github actions workflow files super easy 👍  